### PR TITLE
Fix edit recording titles UI

### DIFF
--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useRef, useEffect } from 'react';
 import { TextField, Fade } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 
@@ -20,15 +20,16 @@ export default function EditableText({
   const [editing, setEditing] = useState(false);
   const [newTextValue, setNewTextValue] = useState(textValue);
   const [hoverRef, hovered] = useHover();
+  const inputElement = useRef(null);
 
   const handleClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     setEditing(true);
   };
 
-  const handleChangeCommitted = () => {
+  const commitChanges = (value: string) => {
     setEditing(false);
-    onChangeCommitted(newTextValue);
+    onChangeCommitted(value);
   };
 
   const handleChange = (
@@ -37,17 +38,38 @@ export default function EditableText({
     setNewTextValue(event.target.value);
   };
 
+  const handleBlur = () => {
+    setEditing(false);
+    onChangeCommitted(newTextValue);
+  };
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        commitChanges(newTextValue);
+      }
+    };
+    if (editing && inputElement.current) {
+      inputElement.current.addEventListener('keydown', handleKeydown);
+    }
+
+    return () => {
+      removeEventListener('keydown', handleKeydown);
+    };
+  }, [editing, newTextValue]);
+
   if (editing)
     return (
       <div style={{ display: 'flex' }}>
         <div>
           <TextField
+            ref={inputElement}
             placeholder={textValue}
             value={newTextValue}
             size={size}
             autoFocus
             fullWidth
-            onBlur={handleChangeCommitted}
+            onBlur={handleBlur}
             onChange={handleChange}
             variant="standard"
             onDoubleClick={(event: React.MouseEvent) => event.stopPropagation()}

--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -60,26 +60,24 @@ export default function EditableText({
 
   if (editing)
     return (
-      <div style={{ display: 'flex' }}>
-        <div>
-          <TextField
-            ref={inputElement}
-            placeholder={textValue}
-            value={newTextValue}
-            size={size}
-            autoFocus
-            fullWidth
-            onBlur={handleBlur}
-            onChange={handleChange}
-            variant="standard"
-            onDoubleClick={(event: React.MouseEvent) => event.stopPropagation()}
-          />
-        </div>
-      </div>
+      <span style={{ display: 'flex', width: '100%' }}>
+        <TextField
+          ref={inputElement}
+          placeholder={textValue}
+          value={newTextValue}
+          size={size}
+          autoFocus
+          fullWidth
+          onBlur={handleBlur}
+          onChange={handleChange}
+          variant="standard"
+          onDoubleClick={(event: React.MouseEvent) => event.stopPropagation()}
+        />
+      </span>
     );
 
   return (
-    <div
+    <span
       style={{
         display: 'flex',
         cursor: 'pointer',
@@ -95,6 +93,6 @@ export default function EditableText({
           <EditIcon fontSize="small" color="disabled" />
         </Fade>
       </div>
-    </div>
+    </span>
   );
 }

--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -1,62 +1,71 @@
-import React, { ChangeEvent, useState } from 'react'
-import { TextField, Fade } from '@mui/material'
+import React, { ChangeEvent, useState } from 'react';
+import { TextField, Fade } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 
 import useHover from '../hooks/useHover';
 
 type EditableTextProps = {
   textValue: string;
-  children: React.ReactChild;
+  children: React.ReactNode;
   size?: 'small' | 'medium';
   onChangeCommitted(newTextValue: string): void;
-}
+};
 
 export default function EditableText({
-  textValue, 
-  size = 'medium', 
+  textValue,
+  size = 'medium',
   onChangeCommitted,
-  children, 
+  children,
 }: EditableTextProps) {
-  const [editing, setEditing] = useState(false)
-  const [newTextValue, setNewTextValue] = useState(textValue)
+  const [editing, setEditing] = useState(false);
+  const [newTextValue, setNewTextValue] = useState(textValue);
   const [hoverRef, hovered] = useHover();
 
+  const handleClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setEditing(true);
+  };
+
   const handleChangeCommitted = () => {
-    setEditing(false)
-    onChangeCommitted(newTextValue)
-  }
+    setEditing(false);
+    onChangeCommitted(newTextValue);
+  };
 
-  const handleChange = (event: ChangeEvent<{ name?: string; value: string }>)=> {
-    setNewTextValue(event.target.value)
-  }
+  const handleChange = (
+    event: ChangeEvent<{ name?: string; value: string }>
+  ) => {
+    setNewTextValue(event.target.value);
+  };
 
-  if (editing) return (
-    <div style={{ display: 'flex' }}>
-      <div>
-        <TextField 
-          placeholder={textValue}
-          value={newTextValue}
-          size={size}
-          autoFocus
-          fullWidth
-          onBlur={handleChangeCommitted}
-          onChange={handleChange}
-          variant="standard"
-        />
+  if (editing)
+    return (
+      <div style={{ display: 'flex' }}>
+        <div>
+          <TextField
+            placeholder={textValue}
+            value={newTextValue}
+            size={size}
+            autoFocus
+            fullWidth
+            onBlur={handleChangeCommitted}
+            onChange={handleChange}
+            variant="standard"
+            onDoubleClick={(event: React.MouseEvent) => event.stopPropagation()}
+          />
+        </div>
       </div>
-    </div>
-  )
+    );
 
   return (
     <div
       style={{
         display: 'flex',
         cursor: 'pointer',
-          textDecoration:
-            hovered ? 'underline' : 'none',
-      }} 
+        textDecoration: hovered ? 'underline' : 'none',
+      }}
       ref={hoverRef}
-      onClick={() => setEditing(true)}
+      onClick={handleClick}
+      onDoubleClick={handleClick}
     >
       {children}
       <div style={{ marginLeft: 4 }}>
@@ -65,5 +74,5 @@ export default function EditableText({
         </Fade>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/RecordingsListItem.tsx
+++ b/src/components/RecordingsListItem.tsx
@@ -123,17 +123,23 @@ export function RecordingsListItem({
               justifyContent: 'space-between',
             }}
           >
-            <EditableText
-              textValue={recording.title}
-              size="small"
-              onChangeCommitted={handleSubimtTitleChange}
-            >
-              <Tooltip title={recording.title} enterDelay={400}>
-                <Typography style={{ maxWidth: '50vw' }} noWrap>
-                  {recording.title}
-                </Typography>
-              </Tooltip>
-            </EditableText>
+            {selected ? (
+              <EditableText
+                textValue={recording.title}
+                size="small"
+                onChangeCommitted={handleSubimtTitleChange}
+              >
+                <Tooltip title={recording.title} enterDelay={400}>
+                  <Typography style={{ maxWidth: '50vw' }} noWrap>
+                    {recording.title}
+                  </Typography>
+                </Tooltip>
+              </EditableText>
+            ) : (
+              <Typography style={{ maxWidth: '50vw' }} noWrap>
+                {recording.title}
+              </Typography>
+            )}
             {selected && (
               <div
                 style={{

--- a/src/components/RecordingsListItem.tsx
+++ b/src/components/RecordingsListItem.tsx
@@ -124,27 +124,32 @@ export function RecordingsListItem({
             }}
           >
             {selected ? (
-              <EditableText
-                textValue={recording.title}
-                size="small"
-                onChangeCommitted={handleSubimtTitleChange}
-              >
-                <Tooltip title={recording.title} enterDelay={400}>
+              <Tooltip title={recording.title} enterDelay={600}>
+                <EditableText
+                  textValue={recording.title}
+                  size="small"
+                  onChangeCommitted={handleSubimtTitleChange}
+                >
                   <Typography style={{ maxWidth: '50vw' }} noWrap>
                     {recording.title}
                   </Typography>
-                </Tooltip>
-              </EditableText>
+                </EditableText>
+              </Tooltip>
             ) : (
-              <Typography style={{ maxWidth: '50vw' }} noWrap>
-                {recording.title}
-              </Typography>
+              <Tooltip title={recording.title} enterDelay={600}>
+                <Typography style={{ maxWidth: '50vw' }} noWrap>
+                  {recording.title}
+                </Typography>
+              </Tooltip>
             )}
             {selected && (
               <div
                 style={{
                   color: theme.palette.text.secondary,
                   display: 'flex',
+                  position: 'absolute',
+                  right: 16,
+                  top: 4,
                 }}
               >
                 <div


### PR DESCRIPTION
* Only render `EditableText` if item is selected
* Prevent double click on editing title from opening recording detail
* Add Enter keypress event listener